### PR TITLE
Enable oem2orm to be used via console script

### DIFF
--- a/oem2orm/oep_oedialect_oem2orm.py
+++ b/oem2orm/oep_oedialect_oem2orm.py
@@ -258,7 +258,7 @@ def select_oem_dir(oem_folder_name=None, filename=None):
     if oem_folder_name is not None:
         oem_path = pathlib.Path.cwd() / oem_folder_name
         return oem_path
-    elif oem_folder_name is 'default':
+    elif oem_folder_name == 'default':
         pass
         # default_oem_path =
     else:
@@ -350,7 +350,7 @@ def api_updateMdOnTable(metadata):
     logging.info("UPDATE METADATA")
     api_action = setupApiAction(schema, table)
     resp = requests.post(api_action.dest_url, json=metadata, headers=api_action.headers)
-    if resp.status_code is "200":
+    if resp.status_code == "200":
         logging.info("   ok.")
         logging.info(api_action.dest_url)
     else:

--- a/oem2orm/oep_oedialect_oem2orm.py
+++ b/oem2orm/oep_oedialect_oem2orm.py
@@ -442,11 +442,6 @@ def main():
     ordered_tables = order_tables_by_foreign_keys(tables)
     create_tables(db, ordered_tables)
 
-    delete_tables(db, tables)
-
-    # gdf_awz = gpd.read_file("bsh_seegrenzen_awz.gpkg")
-    # print(gdf_awz)
-
 
 if __name__ == "__main__":
     main()

--- a/oem2orm/oep_oedialect_oem2orm.py
+++ b/oem2orm/oep_oedialect_oem2orm.py
@@ -416,7 +416,7 @@ def setUserToken():
         print("Please provide your OEP-API token.")
 
 
-if __name__ == "__main__":
+def main():
     # Easy cmd usage and testing (development purpose)
 
     logger = logging.getLogger()
@@ -446,4 +446,8 @@ if __name__ == "__main__":
 
     # gdf_awz = gpd.read_file("bsh_seegrenzen_awz.gpkg")
     # print(gdf_awz)
+
+
+if __name__ == "__main__":
+    main()
 

--- a/oem2orm/oep_oedialect_oem2orm.py
+++ b/oem2orm/oep_oedialect_oem2orm.py
@@ -424,7 +424,7 @@ def main():
     metadata_folder = input("Enter metadata folder name:")
     # ToDo: add the review-oemetadata path
     folder = pathlib.Path.cwd() / metadata_folder
-    metadata_files = [str(file) for file in folder.iterdir()]
+    metadata_files = [str(file) for file in folder.iterdir() if str(file).endswith('.json')]
 
     db = setup_db_connection()
 

--- a/oem2orm/requirements.txt
+++ b/oem2orm/requirements.txt
@@ -5,3 +5,4 @@ GeoAlchemy2
 oedialect
 geopandas
 pandas
+omi

--- a/setup.py
+++ b/setup.py
@@ -33,4 +33,7 @@ setuptools.setup(
         'Bug Reports': 'https://github.com/OpenEnergyPlatform/oem2orm/issues',
         'Source': 'https://github.com/OpenEnergyPlatform/oem2orm/tree/develop/oem2orm',
     },
+    entry_points={
+        'console_scripts': ['oem2orm=oem2orm.oep_oedialect_oem2orm:main'],
+    }
 )

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     python_requires='>=3.6',
-    install_requires=['sqlalchemy', 'oedialect', 'requests', 'jmespath'],  # Optional
+    install_requires=['sqlalchemy', 'oedialect', 'requests', 'jmespath', 'omi'],  # Optional
     project_urls={  # Optional
         'Bug Reports': 'https://github.com/OpenEnergyPlatform/oem2orm/issues',
         'Source': 'https://github.com/OpenEnergyPlatform/oem2orm/tree/develop/oem2orm',


### PR DESCRIPTION
With this changes oem2orm can be installed and run from console, e.g. via [pipx](https://github.com/pipxproject/pipx):
```
pipx install oem2orm
oem2orm
Enter metadata folder name:
...
```
Additional changes (which should have gone into separate PR, sorry):
- minor comparison bugs
- removed `delete_tables` at end of `main()` function
- Metadata folder is scanned for _json_ files only

also 
closes #1