### PR TITLE
Import fails after package is installed using pip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Template:
 ### Added
 
 ### Changed
+- fix module not installed error after pip install and import of oem2orm PR(#26)
 ---
 
 ## [0.3.0] - 2022-10-24

--- a/oem2orm/oep_oedialect_oem2orm.py
+++ b/oem2orm/oep_oedialect_oem2orm.py
@@ -17,8 +17,8 @@ import requests
 
 import oedialect
 
-from .postgresql_types import TYPES
-from oep_compliance import run_metadata_checks
+from oem2orm.postgresql_types import TYPES
+from oem2orm.oep_compliance import run_metadata_checks
 
 # prepare connection string to connect via oep API
 CONNECTION_STRING = "{engine}://{user}:{token}@{host}"


### PR DESCRIPTION
change import path to avoide module not installed error

change imports to:
```python
from oem2orm.postgresql_types import TYPES
from oem2orm.oep_compliance import run_metadata_checks
```