### PR TITLE
MetadataError is thrown if uploading metadata to OEP fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ Template:
 
 ### Added
 ### Changed
+- MetadataError is thrown if uploading metadata to OEP fails
+
 ### Removed
 
 ______________________________________________________________________

--- a/oem2orm/oep_oedialect_oem2orm.py
+++ b/oem2orm/oep_oedialect_oem2orm.py
@@ -380,9 +380,11 @@ def api_updateMdOnTable(metadata, token=None):
         logging.info("   ok.")
         logging.info(api_action.dest_url)
     else:
-        logging.info(resp.json())
+        error_msg = resp.json()
+        logging.info(error_msg)
         logging.info("HTTP status code: ")
         logging.info(resp.status_code)
+        raise MetadataError(f"Uploading of metadata failed. Response from OEP: {error_msg}")
 
 
 def api_downloadMd(schema, table, token=None):

--- a/oem2orm/oep_oedialect_oem2orm.py
+++ b/oem2orm/oep_oedialect_oem2orm.py
@@ -376,7 +376,7 @@ def api_updateMdOnTable(metadata, token=None):
     logging.info("UPDATE METADATA")
     api_action = setupApiAction(schema, table, token)
     resp = requests.post(api_action.dest_url, json=metadata, headers=api_action.headers)
-    if resp.status_code == "200":
+    if resp.status_code == 200:
         logging.info("   ok.")
         logging.info(api_action.dest_url)
     else:


### PR DESCRIPTION
Fixes #29 

This could lead to errors in other packages, where error is ignored as before.